### PR TITLE
Porting nstack to canonical/microkelvin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/dusk-network/nstack"
 keywords = ["merkle", "datastructure", "stack"]
 
 [dependencies]
-microkelvin = { path = "../microkelvin" }
-canonical = { path = "../canonical/canon" }
-canonical_derive = { path = "../canonical/canon_derive" }
-canonical_host = { path = "../canonical/canon_host" }
+microkelvin = "0.1"
+canonical = "0.3"
+canonical_derive = "0.3"
+canonical_host = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,7 @@ repository = "https://github.com/dusk-network/nstack"
 keywords = ["merkle", "datastructure", "stack"]
 
 [dependencies]
-kelvin = "0.19.0"
+kelvin = { path = "../kelvin" }
+canonical = { path = "../canonical/canon" }
+canonical_derive = { path = "../canonical/canon_derive" }
+canonical_host = { path = "../canonical/canon_host" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/dusk-network/nstack"
 keywords = ["merkle", "datastructure", "stack"]
 
 [dependencies]
-kelvin = { path = "../kelvin" }
-canonical = { path = "../canonical/canon" }
-canonical_derive = { path = "../canonical/canon_derive" }
-canonical_host = { path = "../canonical/canon_host" }
+microkelvin = { path = "../microkelvin" }
+canonical = "0.2.0"
+canonical_derive = "0.2.0"
+canonical_host = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ keywords = ["merkle", "datastructure", "stack"]
 
 [dependencies]
 microkelvin = { path = "../microkelvin" }
-canonical = "0.2"
-canonical_derive = "0.2"
-canonical_host = "0.2"
+canonical = { path = "../canonical/canon" }
+canonical_derive = { path = "../canonical/canon_derive" }
+canonical_host = { path = "../canonical/canon_host" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,64 +8,90 @@
 //!
 //! A stack datastructure with indexed lookup.
 #![warn(missing_docs)]
-use std::borrow::Borrow;
-use std::marker::PhantomData;
-use std::mem;
+use core::mem;
 
 use canonical::{Canon, Store};
 use canonical_derive::Canon;
 
-use kelvin::annotations::{Cardinality, Counter, Nth};
-use kelvin::{
-    Annotation, Branch, BranchMut, Compound, Handle, HandleMut, HandleType,
+use microkelvin::{
+    Annotated, Annotation, Branch, Cardinality, Compound, Traverse,
 };
 
 const N: usize = 4;
 
-/// A stack datastructure with indexed lookup.
-#[derive(Clone, Canon)]
-pub struct NStack<T, A, S>([Handle<Self, S>; N], PhantomData<(T, A)>)
-where
-    T: Canon<S>,
-    Self: Compound<S>,
-    S: Store;
-
-impl<T, A, S> Default for NStack<T, A, S>
-where
-    T: Canon<S>,
-    A: Canon<S> + Annotation<T, S>,
-    S: Store,
-{
-    fn default() -> Self {
-        let handles: [Handle<Self, S>; N] = Default::default();
-        NStack(handles, PhantomData)
-    }
+#[derive(Clone, Canon, Debug)]
+pub enum NStack<T, A, S: Store> {
+    Leaf([Option<T>; N]),
+    Node([Option<Annotated<NStack<T, A, S>, A, S>>; N]),
 }
 
-impl<T, A, S> Compound<S> for NStack<T, A, S>
+impl<T, A, S> Compound for NStack<T, A, S>
 where
-    T: Canon<S>,
-    A: Canon<S> + Annotation<T, S>,
+    Self: Canon<S>,
+    A: Annotation<T>,
     S: Store,
 {
     type Leaf = T;
     type Annotation = A;
 
-    fn children(&self) -> &[Handle<Self, S>] {
-        &self.0
+    fn annotation(&self) -> Self::Annotation {
+        match self {
+            NStack::Leaf([None, ..]) => A::identity(),
+            NStack::Leaf([Some(a), None, ..]) => A::from_leaf(a),
+            NStack::Leaf([Some(a), Some(b), None, ..]) => {
+                A::op(&A::from_leaf(a), &A::from_leaf(b))
+            }
+            NStack::Leaf([Some(a), Some(b), Some(c), None]) => A::op(
+                &A::op(&A::from_leaf(a), &A::from_leaf(b)),
+                &A::from_leaf(c),
+            ),
+            NStack::Leaf([Some(a), Some(b), Some(c), Some(d)]) => A::op(
+                &A::op(&A::from_leaf(a), &A::from_leaf(b)),
+                &A::op(&A::from_leaf(c), &A::from_leaf(d)),
+            ),
+            NStack::Leaf(_) => unreachable!("Invalid leaf structure"),
+
+            NStack::Node([None, ..]) => A::identity(),
+            NStack::Node([Some(a), None, ..]) => a.annotation().clone(),
+            NStack::Node([Some(a), Some(b), None, ..]) => {
+                A::op(a.annotation(), b.annotation())
+            }
+            NStack::Node([Some(a), Some(b), Some(c), None]) => {
+                A::op(&A::op(a.annotation(), b.annotation()), c.annotation())
+            }
+            NStack::Node([Some(a), Some(b), Some(c), Some(d)]) => A::op(
+                &A::op(a.annotation(), b.annotation()),
+                &A::op(c.annotation(), d.annotation()),
+            ),
+            NStack::Node(_) => unreachable!("Invalid node structure"),
+        }
     }
 
-    fn children_mut(&mut self) -> &mut [Handle<Self, S>] {
-        &mut self.0
+    fn traverse<M: Annotation<<Self as Compound>::Leaf>>(
+        &self,
+        method: &mut M,
+    ) -> Traverse {
+        todo!()
     }
 }
 
-enum PushResult<T> {
+impl<T, A, S> Default for NStack<T, A, S>
+where
+    T: Canon<S>,
+    A: Canon<S>,
+    S: Store,
+{
+    fn default() -> Self {
+        NStack::Leaf([None, None, None, None])
+    }
+}
+
+enum Push<T> {
     Ok,
-    NoRoom(T, usize),
+    NoRoom { t: T, depth: usize },
 }
 
-enum PopResult<T> {
+enum Pop<T> {
     Ok(T),
     Last(T),
     None,
@@ -74,7 +100,7 @@ enum PopResult<T> {
 impl<T, A, S> NStack<T, A, S>
 where
     T: Canon<S>,
-    A: Canon<S> + Annotation<T, S>,
+    A: Canon<S> + Annotation<T>,
     S: Store,
 {
     /// Creates a new empty NStack
@@ -85,97 +111,94 @@ where
     /// Pushes a new element onto the stack
     pub fn push(&mut self, t: T) -> Result<(), S::Error> {
         match self._push(t)? {
-            PushResult::Ok => Ok(()),
-            PushResult::NoRoom(t, _) => {
-                // in this branch we determined that the node is full with leaves or nodes,
-                // so we just wrap it in a new root node and recurse
-
+            Push::Ok => Ok(()),
+            Push::NoRoom { t, .. } => {
                 let old_root = mem::take(self);
 
+                let mut new_node = [None, None, None, None];
+                new_node[0] = Some(Annotated::new(old_root)?);
+
+                *self = NStack::Node(new_node);
+
                 // the first child of our new root will be our old root
-                self.0[0] = Handle::new_node(old_root)?;
-                // recurse
                 self.push(t)
             }
         }
     }
 
-    fn _push(&mut self, t: T) -> Result<PushResult<T>, S::Error> {
-        #[derive(Debug)]
-        enum State {
-            Initial,
-            SeenNode(usize),
-        }
-        use State::*;
-
-        let mut state = Initial;
-
-        for i in 0..N {
-            match (&state, self.0[i].handle_type()) {
-                (Initial, HandleType::None) => {
-                    self.0[i] = Handle::new_leaf(t);
-                    return Ok(PushResult::Ok);
+    fn _push(&mut self, t: T) -> Result<Push<T>, S::Error> {
+        match self {
+            NStack::Leaf(leaf) => {
+                for i in 0..N {
+                    match leaf[i] {
+                        ref mut empty @ None => {
+                            *empty = Some(t);
+                            return Ok(Push::Ok);
+                        }
+                        Some(_) => (),
+                    }
                 }
-                (Initial, HandleType::Leaf) => (),
-                (Initial, HandleType::Node) => state = SeenNode(i),
-                (SeenNode(_), HandleType::None) => {
-                    // we found the last node
-                    break;
-                }
-                (SeenNode(_), HandleType::Leaf) => {
-                    unreachable!("invariant: no nodes and leaves on same level")
-                }
-                (SeenNode(_), HandleType::Node) => state = SeenNode(i),
+                return Ok(Push::NoRoom { t, depth: 0 });
             }
-        }
+            NStack::Node(node) => {
+                let mut insert_node = None;
 
-        match state {
-            Initial => Ok(PushResult::NoRoom(t, 0)),
-            SeenNode(i) => {
-                let insert_new;
+                // find last node, searching from reverse
+                for i in 0..N {
+                    let i = N - i - 1;
 
-                match self.0[i].inner_mut()? {
-                    HandleMut::Node(ref mut n) => {
-                        match n.val_mut(|n| n._push(t.clone()))? {
-                            PushResult::Ok => return Ok(PushResult::Ok),
-                            PushResult::NoRoom(t, depth) => {
-                                // we need to create a new branch
-                                // is there space here?
-                                if i == N - 1 {
-                                    // no space for new branch
-                                    return Ok(PushResult::NoRoom(
-                                        t,
-                                        depth + 1,
-                                    ));
-                                } else {
-                                    let mut new_node = Self::new();
-                                    new_node.0[0] = Handle::new_leaf(t);
+                    match &mut node[i] {
+                        None => (),
+                        Some(annotated) => {
+                            match annotated.val_mut()?._push(t)? {
+                                Push::Ok => return Ok(Push::Ok),
+                                Push::NoRoom { t, depth } => {
+                                    // Are we in the last node
+                                    if i == N - 1 {
+                                        return Ok(Push::NoRoom {
+                                            t,
+                                            depth: depth + 1,
+                                        });
+                                    } else {
+                                        // create a new node
+                                        let mut new_node = NStack::Leaf([
+                                            Some(t),
+                                            None,
+                                            None,
+                                            None,
+                                        ]);
 
-                                    // wrap the node in a long enough branch
+                                        // give it enough depth
+                                        for _ in 0..depth {
+                                            let old_root = mem::replace(
+                                                &mut new_node,
+                                                NStack::new(),
+                                            );
+                                            new_node = NStack::Node([
+                                                Some(Annotated::new(old_root)?),
+                                                None,
+                                                None,
+                                                None,
+                                            ]);
+                                        }
 
-                                    for _ in 0..depth {
-                                        let inner = mem::replace(
-                                            &mut new_node,
-                                            Self::new(),
-                                        );
-                                        new_node.0[0] =
-                                            Handle::new_node(inner)?;
+                                        // Insert node
+                                        insert_node = Some((new_node, i + 1));
+                                        break;
                                     }
-
-                                    insert_new = Some(new_node);
                                 }
                             }
                         }
                     }
-                    _ => unreachable!("Seen node"),
+                }
+                // break out and insert
+                if let Some((new_node, index)) = insert_node {
+                    node[index] = Some(Annotated::new(new_node)?);
+                } else {
+                    unreachable!()
                 }
 
-                if let Some(new_node) = insert_new {
-                    self.0[i + 1] = Handle::new_node(new_node)?;
-                    Ok(PushResult::Ok)
-                } else {
-                    unreachable!();
-                }
+                Ok(Push::Ok)
             }
         }
     }
@@ -185,76 +208,67 @@ where
     /// Returns the popped element, if any.
     pub fn pop(&mut self) -> Result<Option<T>, S::Error> {
         match self._pop()? {
-            PopResult::Ok(t) | PopResult::Last(t) => Ok(Some(t)),
-            PopResult::None => Ok(None),
+            Pop::Ok(t) | Pop::Last(t) => Ok(Some(t)),
+            Pop::None => Ok(None),
         }
     }
 
-    fn _pop(&mut self) -> Result<PopResult<T>, S::Error> {
-        for i in 0..N {
-            // reverse iteration
-            let i = N - i - 1;
+    fn _pop(&mut self) -> Result<Pop<T>, S::Error> {
+        let mut clear_node = None;
 
-            match self.0[i].handle_type() {
-                HandleType::None => (),
-                HandleType::Leaf => {
-                    let popped =
-                        mem::replace(&mut self.0[i], Handle::new_empty())
-                            .into_leaf();
-
-                    // did we remove the last element?
-                    return Ok(if i == 0 {
-                        PopResult::Last(popped)
-                    } else {
-                        PopResult::Ok(popped)
-                    });
-                }
-                HandleType::Node => match self.0[i].inner_mut()? {
-                    HandleMut::Node(ref mut n) => {
-                        match n.val_mut(|n| n._pop())? {
-                            PopResult::Ok(t) => return Ok(PopResult::Ok(t)),
-                            PopResult::Last(t) => {
-                                n.replace(Handle::new_empty());
-
-                                if i == 0 {
-                                    return Ok(PopResult::Last(t));
-                                } else {
-                                    return Ok(PopResult::Ok(t));
-                                }
+        match self {
+            NStack::Leaf(leaf) => {
+                for i in 0..N {
+                    // reverse
+                    let i = N - i - 1;
+                    match leaf[i].take() {
+                        Some(leaf) => {
+                            if i > 0 {
+                                return Ok(Pop::Ok(leaf));
+                            } else {
+                                return Ok(Pop::Last(leaf));
                             }
-                            PopResult::None => {
-                                unreachable!("invariant: no empty subnodes")
-                            }
-                        };
+                        }
+                        None => (),
                     }
-                    _ => unreachable!(
-                        "invariant: no nodes and leaves on same level"
-                    ),
-                },
+                }
+                Ok(Pop::None)
+            }
+            NStack::Node(node) => {
+                for i in 0..N {
+                    // reverse
+                    let i = N - i - 1;
+                    match node[i] {
+                        Some(ref mut subtree) => {
+                            match subtree.val_mut()?._pop()? {
+                                Pop::Ok(t) => return Ok(Pop::Ok(t)),
+                                Pop::Last(t) => {
+                                    if i == 0 {
+                                        return Ok(Pop::Last(t));
+                                    } else {
+                                        clear_node = Some((t, i));
+                                        break;
+                                    }
+                                }
+                                Pop::None => return Ok(Pop::None),
+                            }
+                        }
+                        None => (),
+                    }
+                }
+                if let Some((popped, clear_index)) = clear_node {
+                    node[clear_index] = None;
+                    Ok(Pop::Ok(popped))
+                } else {
+                    unreachable!()
+                }
             }
         }
-        Ok(PopResult::None)
     }
 
-    /// Get a branch pointing to the element stored at index `idx`, if any
-    pub fn get<U>(&self, idx: U) -> Result<Option<Branch<Self, S>>, S::Error>
-    where
-        U: Counter,
-        <Self as Compound<S>>::Annotation: Borrow<Cardinality<U>>,
-    {
-        Branch::new(self, &mut Nth::new(idx))
-    }
-
-    /// Get a mutable branch pointing to the element stored at index `idx`, if any
-    pub fn get_mut<U>(
-        &mut self,
-        idx: U,
-    ) -> Result<Option<BranchMut<Self, S>>, S::Error>
-    where
-        U: Counter,
-        <Self as Compound<S>>::Annotation: Borrow<Cardinality<U>>,
-    {
-        BranchMut::new(self, &mut Nth::new(idx))
+    fn get(&self, i: u64) -> Result<Option<Branch<Self, S>>, S::Error> {
+        let mut search = Cardinality::new(i);
+        Branch::traverse(self, &mut search)
     }
 }
 
@@ -263,19 +277,25 @@ mod tests {
     use super::*;
 
     use canonical_host::MemStore;
-    use kelvin::quickcheck_stack;
-    use kelvin::tests::CorrectEmptyState;
+    use microkelvin::Cardinality;
+    // use kelvin::quickcheck_stack;
 
     #[test]
     fn trivial() {
-        let mut nt = NStack::<_, Cardinality<u64>, MemStore>::new();
+        let mut nt = NStack::<u32, Cardinality, MemStore>::new();
+        assert_eq!(nt.pop().unwrap(), None);
+    }
+
+    #[test]
+    fn push_pop() {
+        let mut nt = NStack::<_, Cardinality, MemStore>::new();
         nt.push(8).unwrap();
         assert_eq!(nt.pop().unwrap(), Some(8));
     }
 
     #[test]
     fn double() {
-        let mut nt = NStack::<_, Cardinality<u64>, MemStore>::new();
+        let mut nt = NStack::<_, Cardinality, MemStore>::new();
         nt.push(0).unwrap();
         nt.push(1).unwrap();
         assert_eq!(nt.pop().unwrap(), Some(1));
@@ -286,7 +306,7 @@ mod tests {
     fn multiple() {
         let n = 1024;
 
-        let mut nt = NStack::<_, Cardinality<u64>, MemStore>::new();
+        let mut nt = NStack::<_, Cardinality, MemStore>::new();
 
         for i in 0..n {
             nt.push(i).unwrap();
@@ -297,62 +317,62 @@ mod tests {
         }
 
         assert_eq!(nt.pop().unwrap(), None);
-        nt.assert_correct_empty_state();
     }
 
     #[test]
     fn get() {
         let n = 128;
 
-        let mut nt = NStack::<_, Cardinality<u64>, MemStore>::new();
+        let mut nstack = NStack::<_, Cardinality, MemStore>::new();
 
-        for i in 0..n {
+        for i in 0u64..n {
             println!("pushing {}", i);
-            nt.push(i).unwrap();
+            nstack.push(i).unwrap();
 
             for o in 0..i {
-                assert_eq!(*nt.get(o).unwrap().unwrap(), o);
+                assert_eq!(*nstack.get(o).unwrap().unwrap(), o);
             }
-            assert!(nt.get(i + 1).unwrap().is_none());
+
+            assert!(nstack.get(i + 1).unwrap().is_none());
         }
     }
 
-    #[test]
-    fn get_mut() {
-        let n = 1024;
+    // #[test]
+    // fn get_mut() {
+    //     let n = 1024;
 
-        let mut nt = NStack::<_, Cardinality<u64>, MemStore>::new();
+    //     let mut nt = NStack::<_, Cardinality<u64>, MemStore>::new();
 
-        for i in 0..n {
-            nt.push(i).unwrap();
-        }
+    //     for i in 0..n {
+    //         nt.push(i).unwrap();
+    //     }
 
-        for i in 0..n {
-            *nt.get_mut(i).unwrap().unwrap() += 1;
-        }
+    //     for i in 0..n {
+    //         *nt.get_mut(i).unwrap().unwrap() += 1;
+    //     }
 
-        for i in 0..n {
-            assert_eq!(*nt.get(i).unwrap().unwrap(), i + 1);
-        }
-    }
+    //     for i in 0..n {
+    //         assert_eq!(*nt.get(i).unwrap().unwrap(), i + 1);
+    //     }
+    // }
 
-    // Assert that all branches are always of the same length
-    #[test]
-    fn branch_lengths() {
-        let n = 256;
+    // // Assert that all branches are always of the same length
+    // #[test]
+    // fn branch_lengths() {
+    //     let n = 256;
 
-        let mut nt = NStack::<_, Cardinality<u64>, MemStore>::new();
+    //     let mut nt = NStack::<_, Cardinality<u64>, MemStore>::new();
 
-        for i in 0..n {
-            nt.push(i).unwrap();
-        }
+    //     for i in 0..n {
+    //         nt.push(i).unwrap();
+    //     }
 
-        let length_zero = nt.get(0).unwrap().unwrap().levels().len();
+    //     let length_zero = nt.get(0).unwrap().unwrap().levels().len();
 
-        for i in 1..n {
-            assert_eq!(length_zero, nt.get(i).unwrap().unwrap().levels().len())
-        }
-    }
+    //     for i in 1..n {
+    //         assert_eq!(length_zero, nt.get(i).unwrap().unwrap().levels().len())
+    //     }
+    // }
 
     // quickcheck_stack!(|| NStack::<_, Cardinality<u64>, MemStore>::new());
 }


### PR DESCRIPTION
Use canonical/microkelvin instead of old kelvin, draft until upstream releases.