### PR TITLE
Update microkelvin dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/dusk-network/nstack"
 keywords = ["merkle", "datastructure", "stack"]
 
 [dependencies]
-microkelvin = "0.4"
+microkelvin = {version = "0.5", features = ["associative"]}
 canonical = "0.4"
 canonical_derive = "0.4"
 canonical_host = "0.4"


### PR DESCRIPTION
Since there's a new version of microkelvin, we need
to update it here in nstack.

Also, in `v0.5.0` the `Associative` trait has been removed
by default and now it's behind a feature.
Therefore, we added it in `Cargo.toml`.

Closes #14