### PR TITLE
Update microkelvin dependency to 0.16.0-rkyv.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.11.0] - 2022-05-18
-
 ### Changed
 
-- Change `microlelvin` dependency version to `0.16.0-rkyv`
+- Update `microkelvin` from `0.13.0-rc.0` to `0.16.0-rkyv.0`
 
 ## [0.10.0] - 2021-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2022-05-18
+
+### Changed
+
+- Change `microlelvin` dependency version to `0.16.0-rkyv`
+
 ## [0.10.0] - 2021-07-27
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nstack"
-version = "0.12.0-rc.0"
+version = "0.15.0-rkyv.0"
 authors = [
     "Kristoffer Ström <kristoffer@dusk.network>",
     "Miłosz Muszyński <milosz@dusk.network>"
@@ -13,8 +13,8 @@ keywords = ["merkle", "datastructure", "stack"]
 
 [dependencies]
 bytecheck = { version = "0.6.7", default-features = false }
-microkelvin = { version = "0.13.0-rc.0", default-features = false }
+microkelvin = { version = "0.16.0-rkyv", default-features = false }
 rkyv = { version = "0.7.29", default-features = false, features = ["validation"] }
 
 [dev-dependencies]
-microkelvin = { version = "0.13.0-rc.0" }
+microkelvin = { version = "0.16.0-rkyv" }


### PR DESCRIPTION
Update microkelvin dependency to 0.16.0-rkyv.0 and change this crate version to 0.15.0-rkyv.0