### PR TITLE
Bump version to `0.16.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] - 2022-10-19
+
 ### Added
 
 - Add annotations specific to the `nstack`
@@ -14,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to use `ranno` annotations
-- Update `microkelvin` from `0.13.0-rc.0` to `0.17`
+- Update `microkelvin` from `0.13.0-rc.0` to `0.17`. The wide range is due to
+  experimentation with `rkyv` in `microkelvin`
 - Change `rust-toolchain` to `stable`
 
 ## [0.10.0] - 2021-07-27
@@ -62,7 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change microkelvin and canonical to version 0.4
 
-[unreleased]: https://github.com/dusk-network/nstack/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/dusk-network/nstack/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/dusk-network/nstack/compare/v0.10.0...v0.16.0
 [0.10.0]: https://github.com/dusk-network/nstack/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/dusk-network/nstack/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/dusk-network/nstack/compare/v0.8.0...v0.8.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nstack"
-version = "0.16.0-rc.0"
+version = "0.16.0"
 authors = [
     "Kristoffer Ström <kristoffer@dusk.network>",
     "Miłosz Muszyński <milosz@dusk.network>",


### PR DESCRIPTION
### Added

- Add annotations specific to the `nstack`

### Changed

- Update to use `ranno` annotations
- Update `microkelvin` from `0.13.0-rc.0` to `0.17`. The wide range is due to experimentation with `rkyv` in `microkelvin`.
- Change `rust-toolchain` to `stable`